### PR TITLE
force connect in initPool()

### DIFF
--- a/src/Pool/CachePool.php
+++ b/src/Pool/CachePool.php
@@ -39,7 +39,7 @@ class CachePool implements PoolInterface
 
     /**
      * @param $key
-	 * @param $force
+     * @param $force
      *
      * @return AbstractAdapter
      */

--- a/src/Pool/CachePool.php
+++ b/src/Pool/CachePool.php
@@ -39,12 +39,13 @@ class CachePool implements PoolInterface
 
     /**
      * @param $key
+	 * @param $force
      *
      * @return AbstractAdapter
      */
-    public function getCache($key)
+    public function getCache($key, $force = false)
     {
-        if (!isset($this->caches[$key])) {
+        if ($force || !isset($this->caches[$key])) {
             if (!isset($this->config[$key])) {
                 throw new \LogicException(sprintf('No set %s cache', $key));
             }
@@ -76,7 +77,7 @@ class CachePool implements PoolInterface
     public function initPool()
     {
         foreach ($this->config as $name => $config) {
-            $this->getCache($name);
+            $this->getCache($name, true);
         }
     }
 }

--- a/src/Pool/DatabasePool.php
+++ b/src/Pool/DatabasePool.php
@@ -38,7 +38,7 @@ class DatabasePool implements PoolInterface
 
     /**
      * @param $key
-	 * @param $force
+     * @param $force
      *
      * @return Database
      */

--- a/src/Pool/DatabasePool.php
+++ b/src/Pool/DatabasePool.php
@@ -38,12 +38,13 @@ class DatabasePool implements PoolInterface
 
     /**
      * @param $key
+	 * @param $force
      *
      * @return Database
      */
-    public function getConnection($key)
+    public function getConnection($key, $force = false)
     {
-        if (!isset($this->connections[$key])) {
+        if ($force || !isset($this->connections[$key])) {
             if (!isset($this->config[$key])) {
                 throw new \LogicException(sprintf('No set %s database', $key));
             }
@@ -73,7 +74,8 @@ class DatabasePool implements PoolInterface
     public function initPool()
     {
         foreach ($this->config as $name => $config) {
-            $this->getConnection($name);
+            $this->getConnection($name, true);
         }
     }
 }
+


### PR DESCRIPTION
Add a parament to force connect when initPool() called.

Scene:
When I start a new process from a worker, a taskworker,  or a server managed user process,  the new process will copy parent's connections, even if I call initPool() at the beginning of process callback.  It's not OK ~

So I make such fix, to use the same way used in onWorkerStart().

`
use FastD\Pool\PoolInterface;
use FastD\Process\AbstractProcess;
use swoole_process;

class Process extends AbstractProcess
{
    public function handle(swoole_process $swoole_process)
    {
        parent::handle($swoole_process);

        // 激活连接池
        foreach (app() as $service) {
            if ($service instanceof PoolInterface) {
                $service->initPool();
            }
        }
    }

    // balabala
}
`